### PR TITLE
chore(ci): wait for mariadb health before migrations and update APP_KEY regex

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -508,9 +508,12 @@ jobs:
             echo "🗄️ Subindo mariadb (sem portas expostas)..."
             docker compose -p livrolog -f docker-compose.prod.yml up -d --remove-orphans --force-recreate
 
-            # Wait specifically for MariaDB health before proceeding
-            echo "⏳ Aguardando health do mariadb..."
-            deadline=$((SECONDS+300))  # 5 minutes timeout for DB startup
+            # Wait specifically for MariaDB health with configurable timeout
+            DB_WAIT_TIMEOUT="${DB_HEALTH_TIMEOUT:-${MARIADB_HEALTH_TIMEOUT:-600}}"
+            [ "$DB_WAIT_TIMEOUT" -gt 1800 ] && DB_WAIT_TIMEOUT=1800
+            
+            echo "⏳ Aguardando health do mariadb (timeout=${DB_WAIT_TIMEOUT}s)..."
+            deadline=$((SECONDS+DB_WAIT_TIMEOUT))
             while true; do
               if docker compose -p livrolog -f docker-compose.prod.yml ps mariadb | grep -q "healthy"; then
                 echo "✅ MariaDB is healthy"
@@ -518,7 +521,7 @@ jobs:
               fi
               
               if [ $SECONDS -ge $deadline ]; then
-                echo "❌ MariaDB health check timed out after 5 minutes"
+                echo "❌ MariaDB health check timed out after ${DB_WAIT_TIMEOUT}s"
                 echo "=== MariaDB Status ==="
                 docker compose -p livrolog ps mariadb
                 echo "=== MariaDB Logs (last 80 lines) ==="


### PR DESCRIPTION
## Summary by Sourcery

Integrate an internal MariaDB container into the production deployment, strengthen environment validation, enforce health checks and optional seeding before migrations, and improve connectivity and rollback diagnostics

New Features:
- Introduce an internal MariaDB service in production Docker Compose with healthcheck and persistent volume
- Add optional database seeding logic based on the presence of a seed file
- Enforce waiting for MariaDB to become healthy before running migrations

Enhancements:
- Refine APP_KEY validation regex to require exactly 44 base64 characters
- Add comprehensive .env database credentials validation and create the DB volume directory
- Replace host.docker.internal connectivity checks with direct container-based checks from the API
- Enhance rollback diagnostics to surface MariaDB, API, and web logs

CI:
- Update GitHub Actions deploy workflow to validate APP_KEY and DB settings, wait for MariaDB health, and run post-migration smoke tests

Deployment:
- Update docker-compose.prod.yml to include a mariadb service with healthcheck, remove exposed DB ports, and add service dependencies to ensure API and web wait for DB readiness

Tests:
- Add php artisan tinker–based database connectivity check after migrations