### PR TITLE
fix(api): register swagger analyser lazily so config:cache works

### DIFF
--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use L5Swagger\GeneratorFactory;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
@@ -44,12 +45,14 @@ class AppServiceProvider extends ServiceProvider
         JsonResource::withoutWrapping();
 
         // L5-Swagger 10+ defaults to an attributes-only analyser, which silently drops this API's
-        // @OA\ docblocks. Registered here rather than in config/l5-swagger.php because the deploy
-        // runs `config:cache`, which cannot serialize objects.
-        config(['l5-swagger.documentations.default.scanOptions.analyser' => new ReflectionAnalyser([
-            new AttributeAnnotationFactory,
-            new DocBlockAnnotationFactory,
-        ])]);
+        // @OA\ docblocks. Injected only when the generator is resolved: setting it eagerly (here or
+        // in config/l5-swagger.php) leaves an object in the config repository and breaks `config:cache`.
+        $this->app->beforeResolving(GeneratorFactory::class, function () {
+            config(['l5-swagger.documentations.default.scanOptions.analyser' => new ReflectionAnalyser([
+                new AttributeAnnotationFactory,
+                new DocBlockAnnotationFactory,
+            ])]);
+        });
 
         // Configure morph map for polymorphic relations (Activity->subject, Notification->notifiable)
         Relation::enforceMorphMap([


### PR DESCRIPTION
Hotfix para o deploy de produção falhando em `main` ([run 30360507568](https://github.com/arnonrdp/LivroLog/actions/runs/30360507568/job/90280023164)).

## Causa

`php artisan config:cache` também dá boot na aplicação, então o `config([...])` no `AppServiceProvider::boot()` deixava um objeto `ReflectionAnalyser` dentro do repositório de config, e a serialização falhava:

```
Your configuration files could not be serialized because the value at
"l5-swagger.documentations.default.scanOptions.analyser" is non-serializable.
Call to undefined method OpenApi\Analysers\ReflectionAnalyser::__set_state()
```

O comentário existente assumia que sair do `config/l5-swagger.php` bastava para evitar isso — não basta.

## Correção

Injeta o analyser via `beforeResolving(GeneratorFactory::class, ...)`, que só dispara no `l5-swagger:generate` e no controller da documentação. O `config:cache` nunca vê o objeto.

## Verificação

- `php artisan config:cache` → `Configuration cached successfully`
- `php artisan l5-swagger:generate` com a config cacheada → 50 paths gerados (os 12 controllers usam `@OA\` em docblocks, nenhum usa atributos, então o analyser segue ativo)
- Pint passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)